### PR TITLE
Add support for defining emergency and control variables in conf.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,4 +25,7 @@ default['php-fpm']['conf_file'] = conf_file
 default['php-fpm']['pid'] = pid
 default['php-fpm']['error_log'] =  error_log
 default['php-fpm']['log_level'] = "notice"
+default['php-fpm']['emergency_restart_threshold'] = 0
+default['php-fpm']['emergency_restart_interval'] = 0
+default['php-fpm']['process_control_timeout'] = 0
 default['php-fpm']['package'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -108,4 +108,5 @@ end
 service "php-fpm" do
   service_name php_fpm_service_name
   supports :start => true, :stop => true, :restart => true, :reload => true
+  action [ :enable ]
 end

--- a/templates/default/php-fpm.conf.erb
+++ b/templates/default/php-fpm.conf.erb
@@ -32,7 +32,7 @@ log_level = <%= node['php-fpm']['log_level'] %>
 ; interval set by emergency_restart_interval then FPM will restart. A value
 ; of '0' means 'Off'.
 ; Default Value: 0
-;emergency_restart_threshold = 0
+emergency_restart_threshold = <%= node['php-fpm']['emergency_restart_threshold'] %>
 
 ; Interval of time used by emergency_restart_interval to determine when
 ; a graceful restart will be initiated.  This can be useful to work around
@@ -40,13 +40,13 @@ log_level = <%= node['php-fpm']['log_level'] %>
 ; Available Units: s(econds), m(inutes), h(ours), or d(ays)
 ; Default Unit: seconds
 ; Default Value: 0
-;emergency_restart_interval = 0
+emergency_restart_interval = <%= node['php-fpm']['emergency_restart_interval'] %>
 
 ; Time limit for child processes to wait for a reaction on signals from master.
 ; Available units: s(econds), m(inutes), h(ours), or d(ays)
 ; Default Unit: seconds
 ; Default Value: 0
-;process_control_timeout = 0
+process_control_timeout = <%= node['php-fpm']['process_control_timeout'] %>
 
 ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
 ; Default Value: yes


### PR DESCRIPTION
Allows defining `emergency_restart_threshold`, `emergency_restart_interval` and `process_control_timeout` in main config.
